### PR TITLE
增加golang版本sm2签名

### DIFF
--- a/models/base.go
+++ b/models/base.go
@@ -7,7 +7,7 @@ type ReqV1 struct {
 type SignatureV1 struct {
 	Sigdat     string `json:"sigdat"` //
 	Sigtim     string `json:"sigtim"`
-	Paltsigdat string `json:"paltsigdat"`
+	Paltsigdat string `json:"paltsigda,omitempty"`
 }
 type RequestV1 struct {
 	Body interface{} `json:"body"`


### PR DESCRIPTION
 我这边走的是直连费saas模式，没办法测试平台签名。用户签名是可以通过的。配置如下， cmb_saas_name 和 cmb_saas_private_key 配置为空

```
[cmb_pay]
cmb_saas_name=""
cmb_url="http://cdctest.cmburl.cn/cdcserver/api/v2"
cmb_saas_private_key=""
cmb_sigdat_defult = "__signature_sigdat__"
cmb_account_url = "http://localhost:8081/api/sign"
```