### PR TITLE
将变量名sm2PrivateKey重命名为sm4PrivateKey

### DIFF
--- a/handler/account/account.go
+++ b/handler/account/account.go
@@ -14,7 +14,7 @@ import (
 // MainAccountInfo
 //  @Description:   获取账务信息
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账号
 //  @param bbknbr 分行号
@@ -22,7 +22,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 // @Date 2023-02-13 13:16:21
-func MainAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr string) (*models.AccountInfoResponse, error) {
+func MainAccountInfo(userId, sm4PrivateKey, userPrivateKey, accnbr, bbknbr string) (*models.AccountInfoResponse, error) {
 	reqData := new(models.AccountDetailsRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountInfo
@@ -40,7 +40,7 @@ func MainAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr strin
 	}
 
 	//  todo 优化
-	res := help.CmbSignRequest(string(req), constants.CmbAccountInfo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountInfo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 
@@ -59,7 +59,7 @@ func MainAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr strin
 // MainAccountHistoryBalance
 //  @Description:   获取历史余额 todo
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 主账户
 //  @param bbknbr 子单元
@@ -70,7 +70,7 @@ func MainAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr strin
 //  @Author  ahKevinXy
 //  @Date2023-04-10 13:48:04
 func MainAccountHistoryBalance(
-	userId, sm2PrivateKey,
+	userId, sm4PrivateKey,
 	userPrivateKey,
 	accnbr,
 	bbknbr,
@@ -96,7 +96,7 @@ func MainAccountHistoryBalance(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountHistoryBalance, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountHistoryBalance, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -114,14 +114,14 @@ func MainAccountHistoryBalance(
 // GetBankLinkNo
 //  @Description:   获取银联号
 //  @param userId 用户ID
-//  @param sm2PrivateKey  对称秘钥
+//  @param sm4PrivateKey  对称秘钥
 //  @param userPrivateKey  用户私钥
 //  @param accnbr  账号
 //  @return *models.AccountBankInfoResponse 请求返回
 //  @return error
 //  @Author  ahKevinXy
 //  @Date 2023-04-10 13:51:13
-func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*models.AccountBankInfoResponse, error) {
+func GetBankLinkNo(userId, sm4PrivateKey, userPrivateKey, accnbr string) (*models.AccountBankInfoResponse, error) {
 	reqData := new(models.AccountBankInfoRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountQueryBankLinkNo
@@ -136,7 +136,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryBankLinkNo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryBankLinkNo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -154,7 +154,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 // GetMainAccountPayBusList
 //  @Description:   获取支付模式 todo 删除
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param buscode
 //  @param category
@@ -162,7 +162,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 //  @return error
 //  @Author  ahKevinXy
 //  @Date 2023-04-10 15:16:34
-//func GetMainAccountPayBusList(userId, sm2PrivateKey, userPrivateKey, buscode string) (*models.QueryAccountTransCodeResponse, error) {
+//func GetMainAccountPayBusList(userId, sm4PrivateKey, userPrivateKey, buscode string) (*models.QueryAccountTransCodeResponse, error) {
 //	reqData := new(models.QueryAccountTransCodeRequest)
 //	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 //	reqData.Request.Head.Funcode = constants.CmbAccountPayModQuery
@@ -177,7 +177,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 //	}
 //
 //	//  todo
-//	res := help.CmbSignRequest(string(req), constants.CmbAccountPayModQuery, userId, userPrivateKey, sm2PrivateKey)
+//	res := help.CmbSignRequest(string(req), constants.CmbAccountPayModQuery, userId, userPrivateKey, sm4PrivateKey)
 //
 //	if res == "" {
 //
@@ -195,7 +195,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 // QueryBatchAccountBalance
 //  @Description:  批量获取余额
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账号
 //  @param buscode 分行号
@@ -203,7 +203,7 @@ func GetBankLinkNo(userId, sm2PrivateKey, userPrivateKey, accnbr string) (*model
 //  @return error
 //  @Author  ahKevinXy
 //  @Date 2023-04-13 13:58:14
-func QueryBatchAccountBalance(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr string) (*models.QueryBatchAccountBalanceResponse, error) {
+func QueryBatchAccountBalance(userId, sm4PrivateKey, userPrivateKey, accnbr, bbknbr string) (*models.QueryBatchAccountBalanceResponse, error) {
 	reqData := new(models.QueryBatchMainAccountBalanceRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountBatchQueryBalance
@@ -221,7 +221,7 @@ func QueryBatchAccountBalance(userId, sm2PrivateKey, userPrivateKey, accnbr, bbk
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchQueryBalance, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchQueryBalance, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 

--- a/handler/account/account_list.go
+++ b/handler/account/account_list.go
@@ -13,7 +13,7 @@ import (
 // @Description:   获取可经办列表
 // @Author ahKevinXy
 // @Date 2023-02-13 13:16:21
-func MainAccountUsers(userId, sm2PrivateKey, userPrivateKey, buscod, busmod string) (*models.MainAccountUsersResponse, error) {
+func MainAccountUsers(userId, sm4PrivateKey, userPrivateKey, buscod, busmod string) (*models.MainAccountUsersResponse, error) {
 	reqData := new(models.MainAccountUsersRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountUserList
@@ -28,7 +28,7 @@ func MainAccountUsers(userId, sm2PrivateKey, userPrivateKey, buscod, busmod stri
 	}
 
 	//  todo 优化 返回参数
-	res := help.CmbSignRequest(string(req), constants.CmbAccountUserList, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountUserList, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 

--- a/handler/account/pay_mod.go
+++ b/handler/account/pay_mod.go
@@ -13,12 +13,12 @@ import (
 // PayMods
 //  @Description:  获取支付模式
 //  @param userId 用户ID
-//  @param sm2PrivateKey 对称加密秘钥
+//  @param sm4PrivateKey 对称加密秘钥
 //  @param userPrivateKey 用户私钥
 //  @param buscode 业务模式
 //  @Author  ahKevinXy
 //  @Date 2023-04-06 19:54:15
-func PayMods(userId, sm2PrivateKey, userPrivateKey, busCode string) (*models.QueryAccountTransCodeResponse, error) {
+func PayMods(userId, sm4PrivateKey, userPrivateKey, busCode string) (*models.QueryAccountTransCodeResponse, error) {
 
 	reqData := new(models.QueryAccountTransCodeRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
@@ -33,7 +33,7 @@ func PayMods(userId, sm2PrivateKey, userPrivateKey, busCode string) (*models.Que
 		return nil, err
 	}
 
-	res := help.CmbSignRequest(string(req), constants.CmbAccountCanPayMod, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountCanPayMod, userId, userPrivateKey, sm4PrivateKey)
 	//todo
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/account/payment.go
+++ b/handler/account/payment.go
@@ -13,7 +13,7 @@ import (
 // MainAccountPaySingle
 //  @Description:   单笔对公支付
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param dbAcc
 //  @param buscode
@@ -36,7 +36,7 @@ import (
 //  @Author  ahKevinXy
 //  @Date 2023-04-10 13:56:28
 func MainAccountPaySingle(userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	dbAcc,
 	buscode,
 	busMode,
@@ -86,7 +86,7 @@ func MainAccountPaySingle(userId,
 		return nil, err
 	}
 
-	res := help.CmbSignRequest(string(req), constants.CmbAccountSinglePay, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountSinglePay, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -104,7 +104,7 @@ func MainAccountPaySingle(userId,
 // MainAccountBatchPay
 //  @Description:  批量支付
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param busCode
 //  @param busMode
@@ -119,7 +119,7 @@ func MainAccountPaySingle(userId,
 //  @Author  ahKevinXy
 //  @Date 2023-04-10 13:57:21
 func MainAccountBatchPay(userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	busCode, //业务代码
 	busMode, // 支付模式
 	dtlNbr,
@@ -151,7 +151,7 @@ func MainAccountBatchPay(userId,
 		return nil, err
 	}
 
-	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQuery, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQuery, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/account/payment_trans.go
+++ b/handler/account/payment_trans.go
@@ -13,7 +13,7 @@ import (
 // QueryAccountPaymentTransInfo
 //  @Description:  企银批量支付批次查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param begDat
 //  @param endDat
@@ -25,7 +25,7 @@ import (
 //  @Author  ahKevinXy
 //  @Date 2023-04-13 16:47:10
 func QueryAccountPaymentTransInfo(userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	begDat,
 	endDat,
 	autStr,
@@ -51,7 +51,7 @@ func QueryAccountPaymentTransInfo(userId,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQueryInfo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQueryInfo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -69,7 +69,7 @@ func QueryAccountPaymentTransInfo(userId,
 // QueryAccountPaymentDetail
 //  @Description:   获取交易明细
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bthNbr
 //  @param autStr
@@ -82,7 +82,7 @@ func QueryAccountPaymentTransInfo(userId,
 //  @Date 2023-04-13 16:51:27
 func QueryAccountPaymentDetail(
 	userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	bthNbr,
 	autStr,
 	rtnStr, ctnKey string,
@@ -107,7 +107,7 @@ func QueryAccountPaymentDetail(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQueryDetail, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayQueryDetail, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, err

--- a/handler/account/refund.go
+++ b/handler/account/refund.go
@@ -13,7 +13,7 @@ import (
 // QueryAccountPaymentRefund
 //  @Description:  跨行退票查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bbkNbr 开户行
 //  @param bgnDat 开始时间
@@ -28,7 +28,7 @@ import (
 //  @Date 2023-04-13 16:59:34
 func QueryAccountPaymentRefund(
 	userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	bbkNbr,
 	bgnDat,
 	endDat,
@@ -59,7 +59,7 @@ func QueryAccountPaymentRefund(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayRefund, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountBatchPayRefund, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/account/statement.go
+++ b/handler/account/statement.go
@@ -15,7 +15,7 @@ import (
 // AsyncStatement
 //  @Description:   异步获取回单
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param eacnbr
 //  @param begdat
@@ -27,7 +27,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date2023-04-10 15:05:15
-func AsyncStatement(userId, sm2PrivateKey, userPrivateKey,
+func AsyncStatement(userId, sm4PrivateKey, userPrivateKey,
 	eacnbr,
 	begdat,
 	enddat,
@@ -53,7 +53,7 @@ func AsyncStatement(userId, sm2PrivateKey, userPrivateKey,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryAsyncStatement, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryAsyncStatement, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -71,7 +71,7 @@ func AsyncStatement(userId, sm2PrivateKey, userPrivateKey,
 // SingleStatementQuery
 //  @Description:  单个回单请求
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param eacnbr
 //  @param quedat
@@ -81,7 +81,7 @@ func AsyncStatement(userId, sm2PrivateKey, userPrivateKey,
 //  @return error
 //  @Author  ahKevinXy
 //  @Date2023-04-10 15:09:21
-func SingleStatementQuery(userId, sm2PrivateKey, userPrivateKey, eacnbr, quedat, trsseq, primod string) (*models.SingleCallBackPdfResponse, error) {
+func SingleStatementQuery(userId, sm4PrivateKey, userPrivateKey, eacnbr, quedat, trsseq, primod string) (*models.SingleCallBackPdfResponse, error) {
 	reqData := new(models.SingleCallBackPdfRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountQuerySingleStatement
@@ -100,7 +100,7 @@ func SingleStatementQuery(userId, sm2PrivateKey, userPrivateKey, eacnbr, quedat,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQuerySingleStatement, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQuerySingleStatement, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -118,7 +118,7 @@ func SingleStatementQuery(userId, sm2PrivateKey, userPrivateKey, eacnbr, quedat,
 // GetStatementPdf
 //  @Description:   获取回单文件
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param taskid
 //  @param qwenab
@@ -127,7 +127,7 @@ func SingleStatementQuery(userId, sm2PrivateKey, userPrivateKey, eacnbr, quedat,
 //  @return error
 //  @Author  ahKevinXy
 //  @Date2023-04-10 15:09:59
-func GetStatementPdf(userId, sm2PrivateKey, userPrivateKey, taskid, qwenab string) (*models.QueryAccountCallbackDownloadPdfResponse, error) {
+func GetStatementPdf(userId, sm4PrivateKey, userPrivateKey, taskid, qwenab string) (*models.QueryAccountCallbackDownloadPdfResponse, error) {
 	reqData := new(models.QueryAccountCallbackDownloadPdfRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbAccountQueryAsyncDownloadStatement
@@ -143,7 +143,7 @@ func GetStatementPdf(userId, sm2PrivateKey, userPrivateKey, taskid, qwenab strin
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryAsyncDownloadStatement, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryAsyncDownloadStatement, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -161,7 +161,7 @@ func GetStatementPdf(userId, sm2PrivateKey, userPrivateKey, taskid, qwenab strin
 // BatchStatementQuery
 //  @Description:  获取回单列表
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bbknbr
 //  @param accnbr
@@ -173,7 +173,7 @@ func GetStatementPdf(userId, sm2PrivateKey, userPrivateKey, taskid, qwenab strin
 //  @return error
 //  @Author  ahKevinXy
 //  @Date2023-04-13 15:40:33
-func BatchStatementQuery(userId, sm2PrivateKey, userPrivateKey,
+func BatchStatementQuery(userId, sm4PrivateKey, userPrivateKey,
 	bbknbr,
 	accnbr,
 	bgndat,
@@ -202,7 +202,7 @@ func BatchStatementQuery(userId, sm2PrivateKey, userPrivateKey,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryTransDetail, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryTransDetail, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/account/trans.go
+++ b/handler/account/trans.go
@@ -13,7 +13,7 @@ import (
 // GetMainAccountTransInfo
 //  @Description:   获取交易信息
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bbknbr 开户行
 //  @param accnbr 账户
@@ -23,7 +23,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date 2023-04-10 14:01:42
-func GetMainAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
+func GetMainAccountTransInfo(userId, sm4PrivateKey, userPrivateKey,
 	bbknbr,
 	accnbr,
 	trsDat,
@@ -45,7 +45,7 @@ func GetMainAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryTransInfo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountQueryTransInfo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -64,7 +64,7 @@ func GetMainAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
 // QueryAccountTransInfo
 //  @Description:   获取交易信息
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bbknbr 开户行
 //  @param accnbr 账户
@@ -76,7 +76,7 @@ func GetMainAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
 //  @return error
 //  @Author  ahKevinXy
 //  @Date 2023-04-13 15:32:25
-func QueryAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
+func QueryAccountTransInfo(userId, sm4PrivateKey, userPrivateKey,
 	bbknbr,
 	accnbr,
 	bgndat,
@@ -105,7 +105,7 @@ func QueryAccountTransInfo(userId, sm2PrivateKey, userPrivateKey,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbAccountGetTransInfo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbAccountGetTransInfo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/payroll/pay.go
+++ b/handler/payroll/pay.go
@@ -13,14 +13,14 @@ import (
 // UnitPayrollPayment
 //  @Description:   代发
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param payMod
 //  @param totalInfo
 //  @param payList
 //  @Author  ahKevinXy
 //  @Date  2023-04-13 19:23:11
-func UnitPayrollPayment(userId, sm2PrivateKey, userPrivateKey string, payMod []*models.Bb6Busmod, totalInfo []*models.Bb6Aclakx1, payList []*models.Bb6Aclaky1) (*models.UnitPayrollPaymentResponse, error) {
+func UnitPayrollPayment(userId, sm4PrivateKey, userPrivateKey string, payMod []*models.Bb6Busmod, totalInfo []*models.Bb6Aclakx1, payList []*models.Bb6Aclaky1) (*models.UnitPayrollPaymentResponse, error) {
 	reqData := new(models.UnitPayrollPaymentRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayroll
@@ -35,7 +35,7 @@ func UnitPayrollPayment(userId, sm2PrivateKey, userPrivateKey string, payMod []*
 		return nil, err
 	}
 
-	res := help.CmbSignRequest(string(req), constants.CmbPayroll, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayroll, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/payroll/pay_test.go
+++ b/handler/payroll/pay_test.go
@@ -9,7 +9,7 @@ import (
 func TestUnitPayrollPayment(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		payMod         []*models.Bb6Busmod
 		totalInfo      []*models.Bb6Aclakx1
@@ -25,7 +25,7 @@ func TestUnitPayrollPayment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := UnitPayrollPayment(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.payMod, tt.args.totalInfo, tt.args.payList)
+			got, err := UnitPayrollPayment(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.payMod, tt.args.totalInfo, tt.args.payList)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("UnitPayrollPayment() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/payroll/query.go
+++ b/handler/payroll/query.go
@@ -13,7 +13,7 @@ import (
 // QueryBatchTransInfo
 //  @Description: 批次与明细查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param buscode 业务编码
 //  @param yurref 业务参考号
@@ -24,7 +24,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 14:47:18
-func QueryBatchTransInfo(userId, sm2PrivateKey, userPrivateKey, buscode, yurref, bthnbr, trxseq, histga string) (*models.QueryBatchTransInfoResponse, error) {
+func QueryBatchTransInfo(userId, sm4PrivateKey, userPrivateKey, buscode, yurref, bthnbr, trxseq, histga string) (*models.QueryBatchTransInfoResponse, error) {
 	reqData := new(models.QueryBatchTransInfoRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollQuery
@@ -45,7 +45,7 @@ func QueryBatchTransInfo(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollQuery, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollQuery, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -63,7 +63,7 @@ func QueryBatchTransInfo(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 // QueryBatchTransList
 //  @Description: 代发批次查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param buscode 业务编码
 //  @param yurref 业务参考号
@@ -75,7 +75,7 @@ func QueryBatchTransInfo(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 14:57:28
-func QueryBatchTransList(userId, sm2PrivateKey, userPrivateKey, buscode, yurref, bgndat, enddat, cntkey, dattyp string) (*models.QueryBatchTransListResponse, error) {
+func QueryBatchTransList(userId, sm4PrivateKey, userPrivateKey, buscode, yurref, bgndat, enddat, cntkey, dattyp string) (*models.QueryBatchTransListResponse, error) {
 	reqData := new(models.QueryBatchTransListRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollQueryBatchList
@@ -96,7 +96,7 @@ func QueryBatchTransList(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryBatchList, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryBatchList, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -114,7 +114,7 @@ func QueryBatchTransList(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 // QueryPayrollTransDetail
 //  @Description: 代发明细查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param reqnbr
 //  @param bthnbr
@@ -124,7 +124,7 @@ func QueryBatchTransList(userId, sm2PrivateKey, userPrivateKey, buscode, yurref,
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 15:02:42
-func QueryPayrollTransDetail(userId, sm2PrivateKey, userPrivateKey, reqnbr, bthnbr, trxseq, histag string) (*models.QueryPayrollTransDetailResponse, error) {
+func QueryPayrollTransDetail(userId, sm4PrivateKey, userPrivateKey, reqnbr, bthnbr, trxseq, histag string) (*models.QueryPayrollTransDetailResponse, error) {
 	reqData := new(models.QueryPayrollTransDetailRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollQueryDetail
@@ -143,7 +143,7 @@ func QueryPayrollTransDetail(userId, sm2PrivateKey, userPrivateKey, reqnbr, bthn
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryDetail, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryDetail, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/payroll/query_test.go
+++ b/handler/payroll/query_test.go
@@ -9,7 +9,7 @@ import (
 func TestQueryBatchTransInfo(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		buscode        string
 		yurref         string
@@ -27,7 +27,7 @@ func TestQueryBatchTransInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryBatchTransInfo(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.buscode, tt.args.yurref, tt.args.bthnbr, tt.args.trxseq, tt.args.histga)
+			got, err := QueryBatchTransInfo(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.buscode, tt.args.yurref, tt.args.bthnbr, tt.args.trxseq, tt.args.histga)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryBatchTransInfo() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -42,7 +42,7 @@ func TestQueryBatchTransInfo(t *testing.T) {
 func TestQueryBatchTransList(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		buscode        string
 		yurref         string
@@ -61,7 +61,7 @@ func TestQueryBatchTransList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryBatchTransList(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.buscode, tt.args.yurref, tt.args.bgndat, tt.args.enddat, tt.args.cntkey, tt.args.dattyp)
+			got, err := QueryBatchTransList(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.buscode, tt.args.yurref, tt.args.bgndat, tt.args.enddat, tt.args.cntkey, tt.args.dattyp)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryBatchTransList() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -76,7 +76,7 @@ func TestQueryBatchTransList(t *testing.T) {
 func TestQueryPayrollTransDetail(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		reqnbr         string
 		bthnbr         string
@@ -93,7 +93,7 @@ func TestQueryPayrollTransDetail(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryPayrollTransDetail(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.reqnbr, tt.args.bthnbr, tt.args.trxseq, tt.args.histag)
+			got, err := QueryPayrollTransDetail(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.reqnbr, tt.args.bthnbr, tt.args.trxseq, tt.args.histag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryPayrollTransDetail() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/payroll/refund.go
+++ b/handler/payroll/refund.go
@@ -12,7 +12,7 @@ import (
 // QueryRefundList
 //  @Description: 退票查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accNbr
 //  @param trstyp
@@ -24,7 +24,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 15:22:17
-func QueryRefundList(userId, sm2PrivateKey, userPrivateKey, accNbr, trstyp, bgndat, enddat, cntkey, reqnbr string) (*models.QueryBatchTransListResponse, error) {
+func QueryRefundList(userId, sm4PrivateKey, userPrivateKey, accNbr, trstyp, bgndat, enddat, cntkey, reqnbr string) (*models.QueryBatchTransListResponse, error) {
 	reqData := new(models.QueryPayrollRefundRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollQueryBatchList
@@ -45,7 +45,7 @@ func QueryRefundList(userId, sm2PrivateKey, userPrivateKey, accNbr, trstyp, bgnd
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryBatchList, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollQueryBatchList, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, err

--- a/handler/payroll/refund_test.go
+++ b/handler/payroll/refund_test.go
@@ -9,7 +9,7 @@ import (
 func TestQueryRefundList(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		accNbr         string
 		trstyp         string
@@ -28,7 +28,7 @@ func TestQueryRefundList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryRefundList(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.accNbr, tt.args.trstyp, tt.args.bgndat, tt.args.enddat, tt.args.cntkey, tt.args.reqnbr)
+			got, err := QueryRefundList(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.accNbr, tt.args.trstyp, tt.args.bgndat, tt.args.enddat, tt.args.cntkey, tt.args.reqnbr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryRefundList() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/payroll/satement.go
+++ b/handler/payroll/satement.go
@@ -13,7 +13,7 @@ import (
 // QueryPayrollStatement
 //  @Description: 代发明细对账单查询请求
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param payeac 付款账户
 //  @param begdat 开始日期
@@ -31,7 +31,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 17:28:32
-func QueryPayrollStatement(userId, sm2PrivateKey, userPrivateKey, payeac, begdat, enddat, buscod, busmod, eacnam, ptyref, trxsrl, minamt, maxamt, prtmod, begidx string) (*models.QueryPayrollStatementResponse, error) {
+func QueryPayrollStatement(userId, sm4PrivateKey, userPrivateKey, payeac, begdat, enddat, buscod, busmod, eacnam, ptyref, trxsrl, minamt, maxamt, prtmod, begidx string) (*models.QueryPayrollStatementResponse, error) {
 	reqData := new(models.QueryPayrollStatementRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollStatement
@@ -57,7 +57,7 @@ func QueryPayrollStatement(userId, sm2PrivateKey, userPrivateKey, payeac, begdat
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollStatement, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollStatement, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -75,14 +75,14 @@ func QueryPayrollStatement(userId, sm2PrivateKey, userPrivateKey, payeac, begdat
 // QueryPayrollStatementDownloadUrl
 //  @Description:   获取回单地址
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param taskid 查询ID
 //  @return *models.QueryBatchTransListResponse
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-14 17:33:31
-func QueryPayrollStatementDownloadUrl(userId, sm2PrivateKey, userPrivateKey, taskid string) (*models.QueryBatchTransListResponse, error) {
+func QueryPayrollStatementDownloadUrl(userId, sm4PrivateKey, userPrivateKey, taskid string) (*models.QueryBatchTransListResponse, error) {
 	reqData := new(models.QueryPayrollStatementDownloadUrlRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollStatementDownloadUrl
@@ -96,7 +96,7 @@ func QueryPayrollStatementDownloadUrl(userId, sm2PrivateKey, userPrivateKey, tas
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollStatementDownloadUrl, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollStatementDownloadUrl, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/payroll/satement_test.go
+++ b/handler/payroll/satement_test.go
@@ -9,7 +9,7 @@ import (
 func TestQueryPayrollStatement(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		payeac         string
 		begdat         string
@@ -34,7 +34,7 @@ func TestQueryPayrollStatement(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryPayrollStatement(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.payeac, tt.args.begdat, tt.args.enddat, tt.args.buscod, tt.args.busmod, tt.args.eacnam, tt.args.ptyref, tt.args.trxsrl, tt.args.minamt, tt.args.maxamt, tt.args.prtmod, tt.args.begidx)
+			got, err := QueryPayrollStatement(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.payeac, tt.args.begdat, tt.args.enddat, tt.args.buscod, tt.args.busmod, tt.args.eacnam, tt.args.ptyref, tt.args.trxsrl, tt.args.minamt, tt.args.maxamt, tt.args.prtmod, tt.args.begidx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryPayrollStatement() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -49,7 +49,7 @@ func TestQueryPayrollStatement(t *testing.T) {
 func TestQueryPayrollStatementDownloadUrl(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		taskid         string
 	}
@@ -63,7 +63,7 @@ func TestQueryPayrollStatementDownloadUrl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := QueryPayrollStatementDownloadUrl(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.taskid)
+			got, err := QueryPayrollStatementDownloadUrl(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.taskid)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("QueryPayrollStatementDownloadUrl() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/payroll_old/pay.go
+++ b/handler/payroll_old/pay.go
@@ -12,7 +12,7 @@ import (
 // CreditHandleOtherBySup
 //  @Description:  超网代发
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param busmod 交易模式
 //  @param total 汇总信息
@@ -21,7 +21,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-18 09:48:49
-func CreditHandleOtherBySup(userId, sm2PrivateKey, userPrivateKey, busmod string, total []*models.Ntagcsaix1, detail []*models.Ntagcsaix2) (*models.PayrollOldCreditOtherBySupResponse, error) {
+func CreditHandleOtherBySup(userId, sm4PrivateKey, userPrivateKey, busmod string, total []*models.Ntagcsaix1, detail []*models.Ntagcsaix2) (*models.PayrollOldCreditOtherBySupResponse, error) {
 
 	reqData := new(models.PayrollOldCreditOtherBySupRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
@@ -44,7 +44,7 @@ func CreditHandleOtherBySup(userId, sm2PrivateKey, userPrivateKey, busmod string
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldSupPay, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldSupPay, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, err

--- a/handler/payroll_old/pay_test.go
+++ b/handler/payroll_old/pay_test.go
@@ -9,7 +9,7 @@ import (
 func TestCreditHandleOtherBySup(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		busmod         string
 		total          []*models.Ntagcsaix1
@@ -25,7 +25,7 @@ func TestCreditHandleOtherBySup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreditHandleOtherBySup(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.busmod, tt.args.total, tt.args.detail)
+			got, err := CreditHandleOtherBySup(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.busmod, tt.args.total, tt.args.detail)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreditHandleOtherBySup() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/payroll_old/query.go
+++ b/handler/payroll_old/query.go
@@ -12,7 +12,7 @@ import (
 // QueryPayRollDetail
 //  @Description:   查询交易概要信息
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param reqnbr
 //  @param bthnbr
@@ -22,7 +22,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-05-21 20:34:03
-func QueryPayRollDetail(userId, sm2PrivateKey, userPrivateKey, reqnbr, bthnbr, trxseq, histag string) (*models.QueryPayRollDetailResponse, error) {
+func QueryPayRollDetail(userId, sm4PrivateKey, userPrivateKey, reqnbr, bthnbr, trxseq, histag string) (*models.QueryPayRollDetailResponse, error) {
 	reqData := new(models.PayrollOldQueryTransRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollOldQueryTrans
@@ -42,7 +42,7 @@ func QueryPayRollDetail(userId, sm2PrivateKey, userPrivateKey, reqnbr, bthnbr, t
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldQueryTrans, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldQueryTrans, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, err

--- a/handler/payroll_old/refund.go
+++ b/handler/payroll_old/refund.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Refund(
-	userId, sm2PrivateKey, userPrivateKey, taskId string) (*models.GetPayrollPdfResponse, error) {
+	userId, sm4PrivateKey, userPrivateKey, taskId string) (*models.GetPayrollPdfResponse, error) {
 	reqData := new(models.PayrollPdfFileRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbPayrollOldQueryTransRefund
@@ -25,7 +25,7 @@ func Refund(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldQueryTransRefund, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldQueryTransRefund, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, err

--- a/handler/payroll_old/trans_code.go
+++ b/handler/payroll_old/trans_code.go
@@ -12,7 +12,7 @@ import (
 // PayMods
 //  @Description:   获取交易模式
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param busCode
 //  @param accnbr
@@ -20,7 +20,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-18 09:45:07
-func PayMods(userId, sm2PrivateKey, userPrivateKey, busCode, accnbr string) (*models.QueryPayrollOldTransCodeResponse, error) {
+func PayMods(userId, sm4PrivateKey, userPrivateKey, busCode, accnbr string) (*models.QueryPayrollOldTransCodeResponse, error) {
 
 	reqData := new(models.QueryPayrollOldTransCodeRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
@@ -37,7 +37,7 @@ func PayMods(userId, sm2PrivateKey, userPrivateKey, busCode, accnbr string) (*mo
 	if err != nil {
 		return nil, err
 	}
-	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldTransCode, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbPayrollOldTransCode, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 

--- a/handler/payroll_old/trans_code_test.go
+++ b/handler/payroll_old/trans_code_test.go
@@ -9,7 +9,7 @@ import (
 func TestPayMods(t *testing.T) {
 	type args struct {
 		userId         string
-		sm2PrivateKey  string
+		sm4PrivateKey  string
 		userPrivateKey string
 		busCode        string
 		accnbr         string
@@ -24,7 +24,7 @@ func TestPayMods(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := PayMods(tt.args.userId, tt.args.sm2PrivateKey, tt.args.userPrivateKey, tt.args.busCode, tt.args.accnbr)
+			got, err := PayMods(tt.args.userId, tt.args.sm4PrivateKey, tt.args.userPrivateKey, tt.args.busCode, tt.args.accnbr)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PayMods() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handler/unit_manager/account.go
+++ b/handler/unit_manager/account.go
@@ -15,7 +15,7 @@ import (
 // AddUnitAccount
 //  @Description:  新增记账单元
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr
 //  @param dmanam
@@ -26,7 +26,7 @@ import (
 //  @Author  ahKevinXy
 //  @Date 2023-04-13 17:28:18
 func AddUnitAccount(
-	userId, sm2PrivateKey, userPrivateKey, accnbr, dmanam, dmanbr string,
+	userId, sm4PrivateKey, userPrivateKey, accnbr, dmanam, dmanbr string,
 
 ) (*models.AddUnitAccountResponse, error) {
 	reqData := new(models.AccountAddUnitRequest)
@@ -47,7 +47,7 @@ func AddUnitAccount(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAddAccount, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAddAccount, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -66,7 +66,7 @@ func AddUnitAccount(
 // CloseUnitAccount
 //  @Description:  关闭记账单元
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账户
 //  @param dmanbr 子单元账号
@@ -78,7 +78,7 @@ func AddUnitAccount(
 //  @Date 2023-04-13 17:46:41
 func CloseUnitAccount(
 	userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	accnbr,
 	bbknbr,
 	dmanbr,
@@ -109,7 +109,7 @@ func CloseUnitAccount(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageCloseAccount, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageCloseAccount, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -127,7 +127,7 @@ func CloseUnitAccount(
 // QueryUnitAccountInfo
 //  @Description:  获取账户信息 可以获取实时余额
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账号
 //  @param dmanbr 子单元
@@ -135,7 +135,7 @@ func CloseUnitAccount(
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-13 17:51:01
-func QueryUnitAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr string) (*models.AccountUnitInfoResponse, error) {
+func QueryUnitAccountInfo(userId, sm4PrivateKey, userPrivateKey, accnbr, dmanbr string) (*models.AccountUnitInfoResponse, error) {
 	reqData := new(models.AccountUnitInfoRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbUnitManageAccountQueryV2
@@ -153,7 +153,7 @@ func QueryUnitAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr 
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountQueryV2, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountQueryV2, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -171,7 +171,7 @@ func QueryUnitAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr 
 // QueryUnitAccountBalanceHistory
 //  @Description:   获取子账户历史余额
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr //账户
 //  @param bbknbr  分行号
@@ -181,7 +181,7 @@ func QueryUnitAccountInfo(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr 
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-05-18 16:56:54
-func QueryUnitAccountBalanceHistory(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr, qrydat, dmanbr string) (*models.QueryUnitAccountBalanceHistoryResponse, error) {
+func QueryUnitAccountBalanceHistory(userId, sm4PrivateKey, userPrivateKey, accnbr, bbknbr, qrydat, dmanbr string) (*models.QueryUnitAccountBalanceHistoryResponse, error) {
 	reqData := new(models.QueryUnitAccountBalanceHistoryRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbUnitAllHistoryBalanceV2
@@ -201,7 +201,7 @@ func QueryUnitAccountBalanceHistory(userId, sm2PrivateKey, userPrivateKey, accnb
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitAllHistoryBalanceV2, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitAllHistoryBalanceV2, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -219,7 +219,7 @@ func QueryUnitAccountBalanceHistory(userId, sm2PrivateKey, userPrivateKey, accnb
 // QueryUnitAccountSingleBalanceHistory
 //  @Description: 获取子单元 余额列表
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param bbknbr 分行号
 //  @param accnbr 账号
@@ -230,7 +230,7 @@ func QueryUnitAccountBalanceHistory(userId, sm2PrivateKey, userPrivateKey, accnb
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-05-19 18:02:13
-func QueryUnitAccountSingleBalanceHistory(userId, sm2PrivateKey, userPrivateKey, accnbr, bbknbr, dmanbr, begdat, enddat string) (*models.QueryUnitAccountSingleBalanceHistoryResponse, error) {
+func QueryUnitAccountSingleBalanceHistory(userId, sm4PrivateKey, userPrivateKey, accnbr, bbknbr, dmanbr, begdat, enddat string) (*models.QueryUnitAccountSingleBalanceHistoryResponse, error) {
 	reqData := new(models.QueryUnitAccountSingleBalanceHistoryRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbUnitHistoryBalanceV2
@@ -252,7 +252,7 @@ func QueryUnitAccountSingleBalanceHistory(userId, sm2PrivateKey, userPrivateKey,
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitHistoryBalanceV2, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitHistoryBalanceV2, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/unit_manager/payment.go
+++ b/handler/unit_manager/payment.go
@@ -13,7 +13,7 @@ import (
 // UnitAccountPayIn
 //  @Description:  子账户内部调账
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr
 //  @param dmadbt
@@ -25,7 +25,7 @@ import (
 //  @Author  ahKevinXy
 //  @Date2023-04-13 17:23:59
 func UnitAccountPayIn(userId,
-	sm2PrivateKey,
+	sm4PrivateKey,
 	userPrivateKey,
 	accnbr,
 	dmadbt,
@@ -52,7 +52,7 @@ func UnitAccountPayIn(userId,
 	}
 
 	//  todo 判断错误信息
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountPayIn, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountPayIn, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/unit_manager/query.go
+++ b/handler/unit_manager/query.go
@@ -13,7 +13,7 @@ import (
 // QueryUnitAccountDetail
 //  @Description:
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param reqNbr
 //  @return *models.QueryUnitAccountDetailResponse
@@ -22,7 +22,7 @@ import (
 //  @Date  2023-04-13 18:13:23
 func QueryUnitAccountDetail(
 	userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 
 	reqNbr string) (*models.QueryUnitAccountDetailResponse, error) {
 	reqData := new(models.QueryUnitTransDetailRequest)
@@ -41,7 +41,7 @@ func QueryUnitAccountDetail(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransQueryDetail, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransQueryDetail, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -59,7 +59,7 @@ func QueryUnitAccountDetail(
 // QueryUnitAccountByBusNo
 //  @Description:  通过业务单号获取结果信息
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param yurref
 //  @param bgndat
@@ -70,7 +70,7 @@ func QueryUnitAccountDetail(
 //  @Date  2023-04-13 18:05:07
 func QueryUnitAccountByBusNo(
 	userId,
-	sm2PrivateKey, userPrivateKey,
+	sm4PrivateKey, userPrivateKey,
 	yurref,
 	bgndat,
 	enddat string) (*models.QueryUnitTransByBusNoResponse, error) {
@@ -92,7 +92,7 @@ func QueryUnitAccountByBusNo(
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransQueryByBusNo, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransQueryByBusNo, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError

--- a/handler/unit_manager/trans.go
+++ b/handler/unit_manager/trans.go
@@ -14,7 +14,7 @@ import (
 // GetUnitAccountTransList
 //  @Description: 记账子单元当天交易查询
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账户
 //  @param dmanbr 子单元
@@ -23,7 +23,7 @@ import (
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-13 18:49:18
-func GetUnitAccountTransList(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr, ctnkey string) (*models.UnitAccountTransDailyResponse, error) {
+func GetUnitAccountTransList(userId, sm4PrivateKey, userPrivateKey, accnbr, dmanbr, ctnkey string) (*models.UnitAccountTransDailyResponse, error) {
 	reqData := new(models.AccountUnitTransDailyRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbUnitManageAccountTransDaily
@@ -42,7 +42,7 @@ func GetUnitAccountTransList(userId, sm2PrivateKey, userPrivateKey, accnbr, dman
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransDaily, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransDaily, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError
@@ -61,7 +61,7 @@ func GetUnitAccountTransList(userId, sm2PrivateKey, userPrivateKey, accnbr, dman
 // GetUnitAccountTransHistoryList
 //  @Description:  获取记账单元历史列表
 //  @param userId
-//  @param sm2PrivateKey
+//  @param sm4PrivateKey
 //  @param userPrivateKey
 //  @param accnbr 账号
 //  @param dmanbr 子单元
@@ -72,7 +72,7 @@ func GetUnitAccountTransList(userId, sm2PrivateKey, userPrivateKey, accnbr, dman
 //  @return error
 //  @Author  ahKevinXy
 //  @Date  2023-04-13 18:53:33
-func GetUnitAccountTransHistoryList(userId, sm2PrivateKey, userPrivateKey, accnbr, dmanbr, begdat, enddat, ctnkey string) (*models.UnitAccountTransHistoryResponse, error) {
+func GetUnitAccountTransHistoryList(userId, sm4PrivateKey, userPrivateKey, accnbr, dmanbr, begdat, enddat, ctnkey string) (*models.UnitAccountTransHistoryResponse, error) {
 	reqData := new(models.AccountUnitTransHistoryRequest)
 	reqData.Request.Head.Reqid = time.Now().Format("20060102150405000") + strconv.Itoa(time.Now().Nanosecond())
 	reqData.Request.Head.Funcode = constants.CmbUnitManageAccountTransHistory
@@ -93,7 +93,7 @@ func GetUnitAccountTransHistoryList(userId, sm2PrivateKey, userPrivateKey, accnb
 	}
 
 	//  todo
-	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransHistory, userId, userPrivateKey, sm2PrivateKey)
+	res := help.CmbSignRequest(string(req), constants.CmbUnitManageAccountTransHistory, userId, userPrivateKey, sm4PrivateKey)
 
 	if res == "" {
 		return nil, cmb_errors.SystemError


### PR DESCRIPTION
sm4为对称密码算法。这个PR将误命名的sm2PrivateKey变量名替换为了sm4PrivateKey

``` go
	userId := uid + "000000"
	reqNewAccountAes, err := Sm4Encrypt([]byte(AESKey), []byte(userId), reqV1Json)
	if err != nil {
		fmt.Println(err)
		return ""
	}
```

https://github.com/ahKevinXy/go-cmb/blame/c4d52255ac1cc94bd2e2a0e35fb1511f1122cb9a/help/sign.go#L100
